### PR TITLE
Remove the default `'/.*'` SW route registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "pwa-module",
   "private": true,
   "contributors": [
     "Pooya Parsa <pooya@pi0.ir>"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pwa-module",
+  "version": "2.0.8",
   "private": true,
   "contributors": [
     "Pooya Parsa <pooya@pi0.ir>"

--- a/packages/workbox/index.js
+++ b/packages/workbox/index.js
@@ -63,7 +63,7 @@ function getOptions (moduleOptions) {
       {
         urlPattern: fixUrl(publicPath + '/.*'),
         handler: 'cacheFirst'
-      },
+      }
       // Cache other routes if offline
       // TODO: Submit PR with better configurable fix, temporarily removing this route registration
       // {

--- a/packages/workbox/index.js
+++ b/packages/workbox/index.js
@@ -65,10 +65,11 @@ function getOptions (moduleOptions) {
         handler: 'cacheFirst'
       },
       // Cache other routes if offline
-      {
-        urlPattern: fixUrl(routerBase + '/.*'),
-        handler: 'networkFirst'
-      }
+      // TODO: Submit PR with better configurable fix, temporarily removing this route registration
+      // {
+      //   urlPattern: fixUrl(routerBase + '/.*'),
+      //   handler: 'networkFirst'
+      // }
     ],
     runtimeCaching: []
   }


### PR DESCRIPTION
This is to allow a temporary solution of avoiding the addition of the following line in the SW:

```js
workboxSW.router.registerRoute(new RegExp('/.*'), workboxSW.strategies.networkFirst({}), 'GET')
```