### PR TITLE
Remove `@nuxtjs/` directory module lookup

### DIFF
--- a/packages/pwa/index.js
+++ b/packages/pwa/index.js
@@ -5,7 +5,7 @@ module.exports = function nuxtPWA (options) {
 
   return sequence(modules, module => {
     return this.requireModule({
-      src: `@nuxtjs/${module}`,
+      src: `pwa-module/packages/${module}`,
       options: options[module]
     })
   })


### PR DESCRIPTION
Force it to look for the modules within the Cloud Four `pwa-module` directory.